### PR TITLE
With no exec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ mk_syntaxdir: luacheckcheck
 	$(MKDIR) -p $(SYNTASTICDIR)
 
 lnk: mk_syntaxdir
-	-$(CP) $(PLUGDIR)/$(MOONCHECK).vim $(SYNTASTICDIR)
-	-$(CP) $(PLUGDIR)/$(MOONC).vim $(SYNTASTICDIR)
+	-$(CP) $(PLUGDIR_)/$(MOONCHECK).vim $(SYNTASTICDIR)
+	-$(CP) $(PLUGDIR_)/$(MOONC).vim $(SYNTASTICDIR)
 
 luacheckcheck: clean
 	$(LUACHECK) --version

--- a/mooncheck
+++ b/mooncheck
@@ -1,60 +1,91 @@
 #!/usr/bin/env moon
 
-
 unless arg[1]
-	print "Usage: mooncheck <filename.moon> [<luacheck-arguments]"
+	io.stderr\write "Usage: mooncheck <filename.moon> [<luacheck-arguments]\n"
 	os.exit 1
 
-class Cmd
-	new: (cmd) =>
-		@cmd = cmd
-		@
-	arg: (...) =>
-		if @args
-			@args ..= " " .. table.concat {...}, " "
+luacheck = require'luacheck'
+parse = require'moonscript.parse'
+compile = require'moonscript.compile'
+util = require'moonscript.util'
+
+warncode = {
+	["011"]: "A syntax error"
+	["021"]: "An invalid inline option"
+	["022"]: "An unpaired inline push directive"
+	["023"]: "An unpaired inline pop directive"
+	["111"]: "Setting an undefined global variable"
+	["112"]: "Mutating an undefined global variable"
+	["113"]: "Accessing an undefined global variable"
+	["121"]: "Setting a read-only global variable"
+	["122"]: "Mutating a read-only global variable"
+	["131"]: "Unused implicitly defined global variable"
+	["211"]: "Unused local variable"
+	["212"]: "Unused argument"
+	["213"]: "Unused loop variable"
+	["221"]: "Local variable is accessed but never set"
+	["231"]: "Local variable is set but never accessed"
+	["232"]: "An argument is set but never accessed"
+	["233"]: "Loop variable is set but never accessed"
+	["311"]: "Value assigned to a local variable is unused"
+	["312"]: "Value of an argument is unused"
+	["313"]: "Value of a loop variable is unused"
+	["314"]: "Value of a field in a table literal is unused"
+	["321"]: "Accessing uninitialized local variable"
+	["411"]: "Redefining a local variable"
+	["412"]: "Redefining an argument"
+	["413"]: "Redefining a loop variable"
+	["421"]: "Shadowing a local variable"
+	["422"]: "Shadowing an argument"
+	["423"]: "Shadowing a loop variable"
+	["431"]: "Shadowing an upvalue"
+	["432"]: "Shadowing an upvalue argument"
+	["433"]: "Shadowing an upvalue loop variable"
+	["511"]: "Unreachable code"
+	["512"]: "Loop can be executed at most once"
+	["521"]: "Unused label"
+	["531"]: "Left-hand side of an assignment is too short"
+	["532"]: "Left-hand side of an assignment is too long"
+	["541"]: "An empty do end block"
+	["542"]: "An empty if branch"
+	["551"]: "An empty statement"
+}
+
+lcopts = {globals: {"arg", "_"}}
+
+ok, cont = pcall ->
+	local moontext
+	io.close assert with file = io.open arg[1]
+		moontext = file\read "*a"
+
+	tree, errmsg = parse.string moontext
+	if errmsg then error errmsg
+
+	luacode, ok, errpos = compile.tree tree
+	unless ok then error errpos
+
+	posmap = util.debug_posmap ok, moontext, luacode
+	chkresult = luacheck.check_strings {luacode}, lcopts
+
+	linebuf = setmetatable {}, __len: => @len
+
+	for l in (posmap.."\n")\gmatch".-\n"
+		lline, mline = l\match"^%d+%s+(%d+):%[.*%]%s+>>%s(%d+)"
+
+		if ll_ = math.tointeger lline
+			linebuf[ll_] = tonumber mline
+			linebuf.len = ll_
+
+	memotbl = {}
+
+	for warn in *chkresult[1] do if mline = linebuf[warn.line]
+		key = "#{mline}#{warncode[warn.code]}"
+		if memotbl[key] then continue
 		else
-			@args = table.concat {...}, " "
+			memotbl[key] = true
+			print"W: #{arg[1]}:#{mline}:#{warncode[warn.code]} '#{warn.name}'"
 
-		@
-	run: =>
-		cmd = io.popen "#{@cmd} #{@args} 2>&1"
-		ret = cmd\read "*a"
-		_, _, ec = cmd\close!
-		ret, ec
-
-opt, target = "", ""
-
-for i in *arg
-	if i\match "^%-[a-zA-Z]+$"
-		opt ..= " #{i}"
-	else
-		target = i
-
-cont, ec = Cmd("moonc")\arg("-p", target)\run!
-
-if ec > 0
-	print "E: #{target}:" .. cont\match("\n.-(%d+).*$") .. ": Failed to parse"
+unless ok
+	io.stderr\write cont..'\n'
 	os.exit 1
-
-fn = os.tmpname!
-fh = io.open fn, "a+"
-fh\write cont
-fh\seek "set"
-lc_tmp = Cmd("luacheck")\arg(opt, "--formatter", "plain", "--no-color", fn)\run!
-fh\close!
-os.remove fn
-mooncx_tmp = Cmd("moonc")\arg("-X", target)\run!
-buf = {}
-
-for l in mooncx_tmp\gmatch "(.-)\n"
-	b, a = l\match("^%d+%s+(%d+):%[.*%]%s+>>%s(%d+)")
-
-	if b_ = tonumber b
-		buf[b_] = tonumber a
-
-for l in lc_tmp\gmatch "(.-)\n"
-	ln, warn = l\match(":(%d+):.-%s+(.*)$")
-
-	if ln_ = tonumber ln
-		print "W: #{target}:#{buf[ln_]}:#{warn}" if buf[ln_]
 

--- a/mooncheck
+++ b/mooncheck
@@ -1,13 +1,19 @@
 #!/usr/bin/env moon
 
-unless arg[1]
-	io.stderr\write "Usage: mooncheck <filename.moon> [<luacheck-arguments]\n"
-	os.exit 1
-
-luacheck = require'luacheck'
+msversion = (require'moonscript.version').version
 parse = require'moonscript.parse'
 compile = require'moonscript.compile'
 util = require'moonscript.util'
+
+lc = do
+	luacheck = require "luacheck"
+	argparse = require "luacheck.argparse"
+	config = require "luacheck.config"
+	multithreading = require "luacheck.multithreading"
+	version = require "luacheck.version"
+	fs = require "luacheck.fs"
+
+	setmetatable {:argparse, :config, :multithreading, :version, :fs}, __index: luacheck
 
 warncode = {
 	["011"]: "A syntax error"
@@ -51,41 +57,206 @@ warncode = {
 	["551"]: "An empty statement"
 }
 
-lcopts = {globals: {"arg", "_"}}
 
-ok, cont = pcall ->
-	local moontext
-	io.close assert with file = io.open arg[1]
-		moontext = file\read "*a"
+default_cache_path = ".luacheckcache"
 
-	tree, errmsg = parse.string moontext
-	if errmsg then error errmsg
+parser = (->
+	with parser = lc.argparse "mooncheck", "luacheck #{lc._VERSION}", "luacheck for moonscript\n  Luacheck: https://github.com/mpeterv/luacheck"
+		with \argument "files"
+			\description (lc.fs.has_lfs and [[List of files, directories and rockspecs to check.
+Pass "-" to check stdin.]] or [[List of files and rockspecs to check.
+Pass "-" to check stdin.]])
+			\args "+"
+			\argname "<file>"
 
-	luacode, ok, errpos = compile.tree tree
-	unless ok then error errpos
+		with \flag("-g --no-global", [[Filter out warnings related to global variables.
+		  Equivalent to --ignore 1.]])
+			\target("global")
+			\action("store_false")
+		with \flag("-u --no-unused", [[Filter out warnings related to unused variables
+and values. Equivalent to --ignore [23].]])
+			\target("unused")
+			\action("store_false")
+		with \flag("-r --no-redefined", [[Filter out warnings related to redefined variables.
+		  Equivalent to --ignore 4.]])
+			\target("redefined")
+			\action("store_false")
 
-	posmap = util.debug_posmap ok, moontext, luacode
-	chkresult = luacheck.check_strings {luacode}, lcopts
+		with \flag("-a --no-unused-args", [[Filter out warnings related to unused arguments and
+		  loop variables. Equivalent to --ignore 21[23].]])
+			\target("unused_args")
+			\action("store_false")
+		with \flag("-s --no-unused-secondaries", [[Filter out warnings related to unused variables set
+together with used ones.]])
+			\target("unused_secondaries")
+			\action("store_false")
+		with \flag("--no-self", "Filter out warnings related to implicit self argument.")
+			\target("self")
+			\action("store_false")
 
-	linebuf = setmetatable {}, __len: => @len
+		parser\option "--std", "Set standard globals. <std> can be one of:" ..
+			"  _G (default) - globals of the current Lua" ..
+			"interpreter;"..
+			"lua51 - globals of Lua 5.1;"..
+			"lua52 - globals of Lua 5.2;"..
+			"lua52c - globals of Lua 5.2 with LUA_COMPAT_ALL;"..
+			"lua53 - globals of Lua 5.3;"..
+			"lua53c - globals of Lua 5.3 with LUA_COMPAT_5_2;"..
+			"luajit - globals of LuaJIT 2.0;"..
+			"ngx_lua - globals of Openresty lua-nginx-module"..
+			"with LuaJIT 2.0;"..
+			"rockspec - globals allowed in rockspecs;"..
+			"min - intersection of globals of Lua 5.1, Lua 5.2,"..
+			"Lua 5.3 and LuaJIT 2.0;"..
+			"max - union of globals of Lua 5.1, Lua 5.2, Lua 5.3"..
+			"and LuaJIT 2.0;"..
+			"busted - globals added by Busted 2.0;"..
+			"none - no standard globals." ..
+			[[Sets can be combined using "+".]]
+		with \option("--globals", "Add custom globals on top of standard ones.")
+			\args "*"
+			\count "*"
+			\argname "<global>"
+			\action "concat"
+			\init(nil)
+		with \option("--read-globals", "Add read-only globals.")
+			\args "*"
+			\count "*"
+			\argname "<global>"
+			\action "concat"
+			\init(nil)
+		with \option("--new-globals", [[Set custom globals. Removes custom globals added
+previously.]])
+			\args "*"
+			\count "*"
+			\argname "<global>"
+			\action "concat"
+			\init(nil)
+		with \option("--new-read-globals", [[Set read-only globals. Removes read-only globals added
+previously.]])
+			\args "*"
+			\count "*"
+			\argname "<global>"
+			\action "concat"
+			\init(nil)
+		parser\flag("-c --compat", "Equivalent to --std max.")
+		parser\flag("-d --allow-defined", "Allow defining globals implicitly by setting them.")
+		parser\flag("-t --allow-defined-top", [[Allow defining globals implicitly by setting them in
+the top level scope.]])
+		parser\flag("-m --module", [[Limit visibility of implicitly defined globals to
+their files.]])
 
-	for l in (posmap.."\n")\gmatch".-\n"
-		lline, mline = l\match"^%d+%s+(%d+):%[.*%]%s+>>%s(%d+)"
+		with \option("--ignore -i", [[Filter out warnings matching these patterns.
+		  If a pattern contains slash, part before slash matches
+			  warning code and part after it matches name of related
+variable. Otherwise, if the pattern contains letters
+or underscore, it matches name of related variable.
+	Otherwise, the pattern matches warning code.]])
+			\args "+"
+			\count "*"
+			\argname "<patt>"
+			\action "concat"
+			\init(nil)
+		with \option("--enable -e", "Do not filter out warnings matching these patterns.")
+			\args "+"
+			\count "*"
+			\argname "<patt>"
+			\action "concat"
+			\init(nil)
+		with \option("--only -o", "Filter out warnings not matching these patterns.")
+			\args "+"
+			\count "*"
+			\argname "<patt>"
+			\action "concat"
+			\init(nil)
 
-		if ll_ = math.tointeger lline
-			linebuf[ll_] = tonumber mline
-			linebuf.len = ll_
+		with \flag("--no-inline", "Disable inline options.")
+			\target("inline")
+			\action("store_false")
 
-	memotbl = {}
+		\mutex( \option("--config", "Path to configuration file. (default: ".. lc.config.default_path..")"), \flag("--no-config", "Do not look up configuration file."))
 
-	for warn in *chkresult[1] do if mline = linebuf[warn.line]
-		key = "#{mline}#{warncode[warn.code]}"
-		if memotbl[key] then continue
-		else
-			memotbl[key] = true
-			print"W: #{arg[1]}:#{mline}:#{warncode[warn.code]} '#{warn.name}'"
+		\option("--filename", [[Use another filename in output and for selecting\nconfiguration overrides.]])
 
-unless ok
-	io.stderr\write cont..'\n'
-	os.exit 1
+		with \option("--exclude-files", "Do not check files matching these globbing patterns.")
+			\args "+"
+			\count "*"
+			\argname "<glob>"
+		with \option("--include-files", [[Do not check files not matching these globbing
+patterns.]])
+			\args "+"
+			\count "*"
+			\argname "<glob>"
+
+		if lc.fs.has_lfs
+			\mutex( \option("--cache", "Path to cache file.", default_cache_path)\defmode "arg", \flag("--no-cache", "Do not use cache."))
+
+		lanes_notice = ""
+
+		if not lc.multithreading.has_lanes
+			 lanes_notice = "\nWarning: LuaLanes not found."
+
+		\option("-j --jobs", "Check <jobs> files in parallel (default: " .. tostring(lc.multithreading.default_jobs .. ")" .. lanes_notice))\convert(tonumber)
+
+		\option("--formatter" , [[Use custom formatter.
+		  <formatter> must be a module name or one of:
+			  TAP - Test Anything Protocol formatter;
+   JUnit - JUnit XML formatter;
+   plain - simple warning-per-line formatter;
+   default - standard formatter.]])
+
+		with \flag("-q --quiet", [[Suppress output for files without warnings.
+		  -qq: Suppress output of warnings.
+   -qqq: Only print total number of warnings and
+	  errors.]])
+			\count "0-3"
+
+		\flag("--codes", "Show warning codes.")
+		\flag("--ranges", "Show ranges of columns related to warnings.")
+		\flag("--no-color", "Do not color output.")
+
+
+		with \flag "-v --version"
+			\action ->
+				print lc.version.string
+				print "MoonScript #{msversion}"
+				os.exit 0
+	)!
+
+lcopts = parser\parse!
+
+for input in *lcopts.files
+	ok, cont = pcall ->
+		io.close assert with file = io.open input
+			moontext = file\read "*a"
+
+			tree, errmsg = parse.string moontext
+			if errmsg then error errmsg
+
+			luacode, ok, errpos = compile.tree tree
+			unless ok then error errpos
+
+			posmap = util.debug_posmap ok, moontext, luacode
+			chkresult = lc.check_strings {luacode}, lcopts
+
+			linebuf = setmetatable {}, __len: => @len
+
+			for l in (posmap.."\n")\gmatch".-\n"
+				lline, mline = l\match"^%d+%s+(%d+):%[.*%]%s+>>%s(%d+)"
+
+				if ll_ = math.tointeger lline
+					linebuf[ll_] = tonumber mline
+					linebuf.len = ll_
+
+			memotbl = {}
+
+			for warn in *chkresult[1] do if mline = linebuf[warn.line]
+				key = "#{mline}#{warncode[warn.code]}"
+				if memotbl[key] then continue
+				else
+					memotbl[key] = true
+					print"W: #{input}:#{mline}:#{warncode[warn.code]} '#{warn.name}'"
+
+	unless ok
+		io.stderr\write cont..'\n'
 

--- a/mooncheck.orig
+++ b/mooncheck.orig
@@ -1,0 +1,62 @@
+#!/usr/bin/env moon
+
+
+unless arg[1]
+	print "Usage: mooncheck <filename.moon> [<luacheck-arguments]"
+	os.exit 1
+
+class Cmd
+	new: (cmd) =>
+		@cmd = cmd
+		@
+	arg: (...) =>
+		if @args
+			@args ..= " " .. table.concat {...}, " "
+		else
+			@args = table.concat {...}, " "
+
+		@
+	run: =>
+		cmd = io.popen "#{@cmd} #{@args} 2>&1"
+		ret = cmd\read "*a"
+		_, _, ec = cmd\close!
+		ret, ec
+
+opt, target = "", ""
+
+for i in *arg
+	if i\match "^%-[a-zA-Z]+$"
+		opt ..= " #{i}"
+	else
+		target = i
+
+opt = ""
+
+cont, ec = Cmd("moonc")\arg("-p", target)\run!
+
+if ec > 0
+	print "E: #{target}:" .. cont\match("\n.-(%d+).*$") .. ": Failed to parse"
+	os.exit 1
+
+fn = os.tmpname!
+fh = io.open fn, "a+"
+fh\write cont
+fh\seek "set"
+lc_tmp = Cmd("luacheck")\arg(opt, "--formatter", "plain", "--no-color", fn)\run!
+fh\close!
+os.remove fn
+mooncx_tmp = Cmd("moonc")\arg("-X", target)\run!
+buf = {}
+
+for l in mooncx_tmp\gmatch "(.-)\n"
+	b, a = l\match("^%d+%s+(%d+):%[.*%]%s+>>%s(%d+)")
+
+	if b_ = tonumber b
+		buf[b_] = tonumber a
+
+for l in lc_tmp\gmatch "(.-)\n"
+	ln, warn = l\match(":(%d+):.-%s+(.*)$")
+
+	if ln_ = tonumber ln
+		print "W: #{target}:#{buf[ln_]}:#{warn}" if buf[ln_]
+


### PR DESCRIPTION
the previous implementation used `io.popen` to execute `luacheck` and `moonc -X`(to take out the _moon_ line with corresponding _lua_ line). New version is using them as modules, and the way reduces the cost to call command, completely imitate `luacheck`'s args.
